### PR TITLE
Allow resolution of file extension when :file is specified

### DIFF
--- a/README.org
+++ b/README.org
@@ -397,6 +397,13 @@ generated and the image is written
 to =org-babel-jupyter-resource-directory=. To specify your own file name
 for the image, set the =:file= header argument.
 
+If no file extension is specified in the provided =:file=, then one will be inferred
+from the returned output. This can be useful in scenarios where the file resulting
+from the src-block can have different types depeneding on the code, e.g. if the image
+type returned can be either =png= or =svg= depending on certain settings, you can
+specify =:file = output= which will be converted into  =output.png= or =output.svg=
+depending on the MIME type return by the executed src-block.
+
 **** Changing the mime-type priority with the =:display= argument
 
 The priority of mimetypes used to display results can be overwritten using the


### PR DESCRIPTION
This is a minor change which allows resolving the filename extension from the MIME type even if `:file` has been specified (and no specific extension was specified in `:file`).

This can be very useful when the MIME type of the output can change between evaluations but one still wants to use filenames other than the automatically generated one from `jupyter-org-image-file-name`.

One pain-point I repeatedly run is that I want to specify `:file`, but the file-extension used is not something I know ahead of time, e.g. if I'm plotting something in Julia, the resulting MIME type will be `png` if I've run `pyplot()` in some previous src-block, while it will be `svg` if I've run `gr()` in a previous src-block. Then it's useful for me to just specify the "base-name", say, `:file image/output` and have `jupyter-emacs` just add the extension based on the output.

A slightly more complex example: (with this branch) I like to add

```org
:file (f-join "assets" "outputs" (sha1 (plist-get (cadr (org-element-at-point)) :value)))
```

as buffer-wide header-args to my Julia blocks. This then generates the filenames from the *contents* of the block rather than the output. This becomes very useful when I then want to publish the resulting files on, say, Github: if I make a change to one src-block, which then alters one of the later figures, I can just re-run the code, get the new figure *which has the same filename as the previous run*, and then I get a diff that is just replacing this one binary file. In contrast, if I use the default provided by `jupyter-org-image-file-name` I now need to add the new file I just generated *and* remove the old file that is no longer referenced by my org-file.

One thing that might be worth changing about my current implementation: maybe it should be a opt-in feature? As in, the current behavior of `#master` stays but then if you do, say, `(setq jupyter-org-add-image-ext-when-needed t)` (which is `nil` by default) it will infer the file extension from the MIME type.

(Also, thank you so much for this awesome package! I've been using it daily for more than a year now, and really couldn't do without it :heart:)