### PR TITLE
Fix jupyter-org--parse-latex-element

### DIFF
--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -1039,20 +1039,13 @@ parsed, wrap DATA in a minipage environment and return it."
   (with-temp-buffer
     (insert data)
     (goto-char (point-min))
-    ;; Try to determine if we are in an environment or fragment
-    (if (save-excursion
-          (forward-char 2)
-          (org-inside-LaTeX-fragment-p))
-        (org-element-latex-fragment-parser)
-      ;; If we are not in a fragment, try to parse an environment
-      (let ((env (ignore-errors
-                   (org-element-latex-environment-parser
-                    (point-max) nil))))
-        (if (eq (org-element-type env) 'latex-environment) env
-          ;; If all else fails, wrap DATA in a minipage
-          ;; environment
-          (jupyter-org-latex-environment
-           (concat "\
+    (let ((context (org-element-context)))
+      (cond ((memq (org-element-type context) '(latex-fragment latex-environment))
+             context)
+            (t
+             ;; If all else fails, wrap DATA in a minipage environment
+             (jupyter-org-latex-environment
+              (concat "\
 \\begin{minipage}{\\textwidth}
 \\begin{flushright}\n" data "\n\\end{flushright}
 \\end{minipage}")))))))


### PR DESCRIPTION
Upstream org commit f01390c changed the behavior of org-inside-LaTeX-fragment-p which now checks for both latex fragments and environments