### PR TITLE
Add org to Package-Requires

### DIFF
--- a/jupyter.el
+++ b/jupyter.el
@@ -5,7 +5,7 @@
 ;; Author: Nathaniel Nicandro <nathanielnicandro@gmail.com>
 ;; Created: 11 Jan 2018
 ;; Version: 0.8.2
-;; Package-Requires: ((emacs "26") (cl-lib "0.5") (zmq "0.10.10") (simple-httpd "1.5.0") (websocket "1.9"))
+;; Package-Requires: ((emacs "26") (cl-lib "0.5") (org "9.1.6") (zmq "0.10.10") (simple-httpd "1.5.0") (websocket "1.9"))
 ;; URL: https://github.com/nnicandro/emacs-jupyter
 
 ;; This program is free software; you can redistribute it and/or


### PR DESCRIPTION
Trying to use the elpaca package manager currently gives bytecomp errors of "Error: Org version mismatch." when trying to use a non-builtin org version. The elpaca dependency manager doesn't load the newer version of org in the bytecomp process since it isn't declared in the Package-Requires section.

I wasn't totally sure what minimum org version to specify, so I went with the org version that shipped with emacs 26.