### PR TITLE
Make the jupyter executable configurable

### DIFF
--- a/jupyter-env.el
+++ b/jupyter-env.el
@@ -38,6 +38,11 @@ directory is where kernel connection files are written to.
 This variable should not be used.  To obtain the runtime directory
 call the function `jupyter-runtime-directory'.")
 
+(defcustom jupyter-executable "jupyter"
+  "The `jupyter` command executable."
+  :type 'string
+  :group 'jupyter)
+
 (defun jupyter-command (&rest args)
   "Run a Jupyter shell command synchronously, return its output.
 The shell command run is
@@ -49,7 +54,12 @@ return nil."
   (let ((stderr-file (make-temp-file "jupyter"))
         (stdout (get-buffer-create " *jupyter-command-stdout*")))
     (unwind-protect
-        (let* ((status (apply #'process-file "jupyter" nil (list stdout stderr-file) nil args))
+        (let* ((status (apply #'process-file
+                              jupyter-executable
+                              nil
+                              (list stdout stderr-file)
+                              nil
+                              args))
                (buffer (find-file-noselect stderr-file)))
           (unwind-protect
               (with-current-buffer buffer


### PR DESCRIPTION
This PR makes the `jupyter` executable configurable.

My use case is setting it to a project-local executable built by Bazel, instead of having a pip-installed executable available in the `$PATH`. 