### PR TITLE
ob-jupyter.el: Delay `org-babel-jupyter-make-local-aliases` hook.

### DIFF
--- a/ob-jupyter.el
+++ b/ob-jupyter.el
@@ -785,7 +785,7 @@ mapped to their appropriate minted language in
 (defun org-babel-jupyter-make-local-aliases ()
   (let ((default-directory user-emacs-directory))
     (org-babel-jupyter-aliases-from-kernelspecs)))
-(add-hook 'org-mode-hook #'org-babel-jupyter-make-local-aliases)
+(add-hook 'org-mode-hook #'org-babel-jupyter-make-local-aliases 10)
 
 (add-hook 'org-export-before-processing-hook #'org-babel-jupyter-setup-export)
 (add-hook 'org-export-before-parsing-hook #'org-babel-jupyter-strip-ansi-escapes)


### PR DESCRIPTION
Ensuring this function is called after `jupyter-org-interaction-mode` in `org-mode-hook` to ensure correct fontification of errors (i.e. handling ansi-color escape characters).