### PR TITLE
Fix jupyter-org--parse-latex-element again

### DIFF
--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -811,14 +811,6 @@ Otherwise, return VALUE formated as a fixed-width `org-element'."
    (t
     (org-element-create 'fixed-width (list :value (format "%S" value))))))
 
-(defun jupyter-org-latex-fragment (value)
-  "Return a latex-fragment `org-element' consisting of VALUE."
-  (org-element-create 'latex-fragment (list :value value)))
-
-(defun jupyter-org-latex-environment (value)
-  "Return a latex-fragment `org-element' consisting of VALUE."
-  (org-element-create 'latex-environment (list :value value)))
-
 (defun jupyter-org-results-drawer (&rest results)
   "Return a drawer `org-element' containing RESULTS.
 RESULTS can be either strings or other `org-element's.  Newlines
@@ -1048,17 +1040,15 @@ fragment or environment is parsed and returned.  If neither can be
 parsed, wrap DATA in a minipage environment and return it."
   (with-temp-buffer
     (insert data)
-    (goto-char (point-min))
-    (let ((context (org-element-context)))
-      (cond ((memq (org-element-type context) '(latex-fragment latex-environment))
-             context)
+    (let ((elts (org-element-map (org-element-parse-buffer)
+                    '(latex-fragment latex-environment) 'identity)))
+      (cond ((and (= (length elts) 1) (car elts)))
             (t
              ;; If all else fails, wrap DATA in a minipage environment
-             (jupyter-org-latex-environment
-              (concat "\
+             (org-element-create 'latex-environment (list :value (concat "\
 \\begin{minipage}{\\textwidth}
 \\begin{flushright}\n" data "\n\\end{flushright}
-\\end{minipage}")))))))
+\\end{minipage}"))))))))
 
 (cl-defmethod jupyter-org-result ((_mime (eql :text/latex)) content params)
   (if (member "raw" (alist-get :result-params params))


### PR DESCRIPTION
Upstream org commit 4fcdcb4 changed the behavior of `org-element-context` which now uses `org-element-deferred-create` which is incompatible with inserting elements created from with-temp-buffer outside its scope.

Note that the first error I ran into which led to this PR was actually
```
Jupyter: I/O subscriber error: (error "‘org-element-at-point’ cannot be used in non-Org buffer #<buffer  *temp*> (fundamental-mode)")
```
which at first I thought was related to #492 which is due to upstream org commit f135954, however I realized that that issued seemed to be fixed in master already and simply adding a call to `(org-mode)` in `jupyter-org--parse-latex-element` fixed that error but exposed this deeper one which I had missed since I upgraded from a commit prior to 4fcdcb4 past commit f135954.

Note that this is the same as #497, except I wasn't paying attention when I created PR #497 from my fork's master instead of a branch.