### PR TITLE
Fix org-element-cache issue with ansi colors

### DIFF
--- a/jupyter-mime.el
+++ b/jupyter-mime.el
@@ -205,23 +205,14 @@ value of t is added to render the escape sequences invisible.
 Also, the `ansi-color-apply-face-function' is hard-coded to a
 custom function that prepends to the face property of the text
 and also sets the FACE-PROP to the prepended face, if FACE-PROP
-is nil it defaults to `font-lock-face'.
-
-For convenience, a jupyter-invisible property is also added with
-a value of t.  This is mainly for modes like `org-mode' which
-strip invisible properties during fontification.  In such cases,
-the jupyter-invisible property can act as an alias to the
-invisible property by adding it to `char-property-alias-alist'."
-  (cl-letf (((symbol-function #'delete-region)
-             (lambda (beg end)
-               (add-text-properties beg end '(invisible t jupyter-invisible t))))
-            (ansi-color-apply-face-function
+is nil it defaults to `font-lock-face'. "
+  (cl-letf ((ansi-color-apply-face-function
              (lambda (beg end face)
                (when face
                  (setq face (list face))
                  (font-lock-prepend-text-property beg end 'face face)
                  (put-text-property beg end (or face-prop 'font-lock-face) face)))))
-    (ansi-color-apply-on-region begin end)))
+    (ansi-color-apply-on-region begin end t)))
 
 ;;; `jupyter-insert' method
 

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -640,8 +640,6 @@ C-x C-e         `jupyter-eval-line-or-region'"
     (add-hook 'after-revert-hook 'jupyter-org-interaction-mode nil t)
     (setq-local char-property-alias-alist
                 (copy-tree char-property-alias-alist))
-    (cl-callf append (alist-get 'invisible char-property-alias-alist)
-      '(jupyter-invisible))
     (unless (cl-find-if
              (lambda (x) (eq (car x) 'jupyter-org-font-lock-ansi-escapes))
              org-font-lock-keywords)
@@ -650,8 +648,6 @@ C-x C-e         `jupyter-eval-line-or-region'"
    (t
     (remove-hook 'completion-at-point-functions 'jupyter-org-completion-at-point t)
     (remove-hook 'after-revert-hook 'jupyter-org-interaction-mode t)
-    (cl-callf2 delq 'jupyter-invisible
-               (alist-get 'invisible char-property-alias-alist))
     (cl-callf2 cl-remove-if
         (lambda (x) (eq (car x) 'jupyter-org-font-lock-ansi-escapes))
         org-font-lock-keywords))))


### PR DESCRIPTION
I was getting really annoyed with all the `org-element-cache` warnings using ob-jupyter with julia which are described in #486 so I tried to figure out what was causing them. I'm not sure if this is the right way to fix it, or if it may also be caused by other things in emcas-jupyter, but so far I haven't been seeing the issue with this patch for my workflows.