### PR TITLE
Fix control characters appearing in connection file.

### DIFF
--- a/jupyter-env.el
+++ b/jupyter-env.el
@@ -165,7 +165,10 @@ The session can be used to write a connection file, see
                (error "`jupyter kernel` failed to show connection file path"))
         (and (process-live-p process)
              (goto-char (point-min))
-             (re-search-forward "Connection file: \\(.+\\)\n" nil t)))
+             (re-search-forward (rx "Connection file: "
+                                    (group (+ (not cntrl)))
+                                    (* whitespace) line-end)
+                                nil t)))
       (let* ((conn-file (concat
                         (save-match-data
                           (file-remote-p default-directory))

--- a/jupyter-env.el
+++ b/jupyter-env.el
@@ -166,7 +166,7 @@ The session can be used to write a connection file, see
         (and (process-live-p process)
              (goto-char (point-min))
              (re-search-forward (rx "Connection file: "
-                                    (group (+ (not cntrl)) ".json")
+                                    (group (+ any) ".json")
                                     (* whitespace) line-end)
                                 nil t)))
       (let* ((conn-file (concat

--- a/jupyter-env.el
+++ b/jupyter-env.el
@@ -166,7 +166,7 @@ The session can be used to write a connection file, see
         (and (process-live-p process)
              (goto-char (point-min))
              (re-search-forward (rx "Connection file: "
-                                    (group (+ (not cntrl)))
+                                    (group (+ (not cntrl)) ".json")
                                     (* whitespace) line-end)
                                 nil t)))
       (let* ((conn-file (concat


### PR DESCRIPTION
Sometimes control characters appear in the connection file name, this is a trivial fix to modify the regular expression to avoid this. One could also improve the expression to pick out the JSON filetype probably, but I wanted to keep the change minor.