### PR TITLE
Make org keybindings and integration optional

### DIFF
--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -123,6 +123,11 @@ See also the docstring of `org-image-actual-width' for more details."
   :group 'ob-jupyter
   :type 'boolean)
 
+(defcustom jupyter-org-want-keybinding t
+  "Whether to enable contextual keybindings."
+  :group 'ob-jupyter
+  :type 'boolean)
+
 (defconst jupyter-org-mime-types '(:text/org
                                    ;; Prioritize images over html
                                    :image/svg+xml :image/jpeg :image/png
@@ -722,11 +727,12 @@ and they only take effect when the variable
                     #'undefined
                   (jupyter-org--define-key-filter key))))))))
 
-(jupyter-org-define-key (kbd "C-x C-e") #'jupyter-eval-line-or-region)
-(jupyter-org-define-key (kbd "C-M-x") #'jupyter-eval-defun)
-(jupyter-org-define-key (kbd "M-i") #'jupyter-inspect-at-point)
-(jupyter-org-define-key (kbd "C-c C-r") #'jupyter-repl-restart-kernel)
-(jupyter-org-define-key (kbd "C-c C-i") #'jupyter-repl-interrupt-kernel)
+(when jupyter-org-want-keybinding
+  (jupyter-org-define-key (kbd "C-x C-e") #'jupyter-eval-line-or-region)
+  (jupyter-org-define-key (kbd "C-M-x") #'jupyter-eval-defun)
+  (jupyter-org-define-key (kbd "M-i") #'jupyter-inspect-at-point)
+  (jupyter-org-define-key (kbd "C-c C-r") #'jupyter-repl-restart-kernel)
+  (jupyter-org-define-key (kbd "C-c C-i") #'jupyter-repl-interrupt-kernel))
 
 ;;; Handling ANSI escapes in kernel output
 

--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -128,6 +128,11 @@ See also the docstring of `org-image-actual-width' for more details."
   :group 'ob-jupyter
   :type 'boolean)
 
+(defcustom jupyter-org-want-integration t
+  "Whether to enable `jupyter-org-interaction-mode' automatically on `org-mode' buffers."
+  :group 'ob-jupyter
+  :type 'boolean)
+
 (defconst jupyter-org-mime-types '(:text/org
                                    ;; Prioritize images over html
                                    :image/svg+xml :image/jpeg :image/png
@@ -843,7 +848,8 @@ C-x C-e         `jupyter-eval-line-or-region'"
         (lambda (x) (eq (car x) 'jupyter-org-font-lock-ansi-escapes))
         org-font-lock-keywords))))
 
-(add-hook 'org-mode-hook 'jupyter-org-interaction-mode)
+(when jupyter-org-want-integration
+  (add-hook 'org-mode-hook 'jupyter-org-interaction-mode))
 
 ;;; Constructing org syntax trees
 


### PR DESCRIPTION
This PR introduces two variables to control the integration with org:

- jupyter-org-want-keybinding
- jupyter-org-want-integration

which are true by default to keep the old behavior. 

I believe org interaction should be optional because any breakage in jupyter package causes issues with org and that is a very frustrating experience for heavy org users. Now with these variables, user can disable the integration for the time being or they can simply turn it on manually on demand.