### PR TITLE
Quote filename when calling jupyter-load-file

### DIFF
--- a/jupyter-python.el
+++ b/jupyter-python.el
@@ -73,7 +73,7 @@ buffer."
        (t nil)))))
 
 (cl-defmethod jupyter-load-file-code (file &context (jupyter-lang python))
-  (concat "%run " file))
+  (concat "%run \"" file "\""))
 
 ;;; `jupyter-org'
 


### PR DESCRIPTION
Not quoting filenames causes the path to be misinterpreted if it contains spaces. Fixes issues #313 and #579 .