### PR TITLE
Fix: set org src block cache (fix autocomplete)

### DIFF
--- a/jupyter-org-client.el
+++ b/jupyter-org-client.el
@@ -618,11 +618,11 @@ source block, return non-nil.  Otherwise, when `point' is not
 inside a Jupyter src-block, return nil."
   (unless jupyter-org--src-block-cache
     (setq jupyter-org--src-block-cache
-          (list (list 'invalid nil (make-marker)
-                      (let ((end (make-marker)))
-                        ;; Move the end marker when text is inserted
-                        (set-marker-insertion-type end t)
-                        end)))))
+          (list 'invalid nil (make-marker)
+                (let ((end (make-marker)))
+                  ;; Move the end marker when text is inserted
+                  (set-marker-insertion-type end t)
+                  end))))
   (if (org-in-src-block-p 'inside)
       (or (jupyter-org--at-cached-src-block-p)
           (when-let* ((el (org-element-at-point))


### PR DESCRIPTION
The completion-at-point functionality is broken because the org src-block-cache is set to a nested list, instead of just a list. Therefore, the pcase-let destructuring in the
jupyter-org--src-block-cache does not work correctly, and fails to bind the cached markers. 'Unnesting' the cache-list fixes the set-cache and completion functionality.

I did not 'investigate' how the what the src-cache is supposed to look like, but it makes sense to me that it should not be a list of lists (as there should probably be only one 'cache' per src-block).